### PR TITLE
ANXOS-390: Add missing build dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Install dependencies and package
         run: |
           pip install -U pip
+          pip install setuptools wheel twine
           pip install -r requirements.txt
 
       - name: Build source and binary distribution package


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish.yml` file. The change ensures that the necessary packaging tools are installed before building the distribution package.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R22): Added installation of `setuptools`, `wheel`, and `twine` to the dependencies step.